### PR TITLE
Wiki as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Monorepo.wiki"]
+	path = Monorepo.wiki
+	url = https://github.com/AutomatingSciencePipeline/Monorepo.wiki.git


### PR DESCRIPTION
When people clone the project (and include the `--recurse-submodules` flag) it will now clone the wiki too. Changes to the wiki can be pushed as well (in Sourcetree it shows up on the side), and this main repo will keep track of what commit of the wiki it last lined up with. 
![image](https://user-images.githubusercontent.com/25965766/213574381-410834ad-14fa-4158-897d-3b1c90773b75.png)

Learn more:

https://stackoverflow.com/questions/6941688/how-to-integrate-a-github-wiki-into-the-main-project

https://git-scm.com/book/en/v2/Git-Tools-Submodules