### PR TITLE
DB Field Renames + Better typescript utilization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
     "cSpell.words": [
         "appspot",
         "configfile",
-        "consts",
         "dotenv",
         "eqcm",
         "firestore",

--- a/apps/backend/app.py
+++ b/apps/backend/app.py
@@ -27,6 +27,7 @@ except ImportError:
 HAS_DOTENV_FILE = load_dotenv("./.env", override=True)
 
 ENV_FIREBASE_CREDENTIALS = "FIREBASE_KEY"
+DB_COLLECTION_EXPERIMENTS = 'Experiments'
 
 FIREBASE_CREDENTIALS = os.environ.get(ENV_FIREBASE_CREDENTIALS)
 if FIREBASE_CREDENTIALS is None:
@@ -44,7 +45,6 @@ firebaseBucket = storage.bucket("gladosbase.appspot.com")
 
 MAX_WORKERS = 1
 runner = ProcessPoolExecutor(MAX_WORKERS)
-DB_COLLECTION_EXPERIMENTS = 'Experiments'
 
 #setting up the Flask webserver (handles the uploaded experiment files)
 flaskApp = Flask(__name__)

--- a/apps/backend/app.py
+++ b/apps/backend/app.py
@@ -37,23 +37,21 @@ if FIREBASE_CREDENTIALS is None:
 else:
     print("Loaded firebase credentials from environment variables")
 
-#Firebase Objects
 firebaseCredentials = credentials.Certificate(json.loads(FIREBASE_CREDENTIALS))
 firebaseApp = firebase_admin.initialize_app(firebaseCredentials)
 firebaseDb = firestore.client()
 firebaseBucket = storage.bucket("gladosbase.appspot.com")
-
-#setting up the app
-flaskApp = Flask(__name__)
-CORS(flaskApp)
 
 MAX_WORKERS = 1
 runner = ProcessPoolExecutor(MAX_WORKERS)
 
 DB_COLLECTION_EXPERIMENTS = 'Experiments'
 
+#setting up the Flask webserver (handles the uploaded experiment files)
+flaskApp = Flask(__name__)
+CORS(flaskApp)
 
-### FLASK API ENDPOINT
+
 @flaskApp.post("/experiment")
 def recv_experiment():
     runner.submit(handle_exceptions_from_run, request.get_json())
@@ -100,38 +98,36 @@ def run_batch(data):
     os.chdir(f'ExperimentFiles/{expId}')
     filepath = download_experiment_files(expId, experiment, trialExtraFile, keepLogs, postProcess)
 
-    #Determining experiment FileType -> how we need to execute it
     rawfiletype, filetype = determine_experiment_file_type(filepath)
     print(f"Raw Filetype: {rawfiletype}\n Filtered Filetype: {filetype}")
 
-    #Generating Configs from hyperparameters
     print(f"Generating configs and downloading to ExperimentFiles/{expId}/configFiles")
-    configResult = generate_config_files(json.loads(experiment['hyperparameters'])['hyperparameters'], dumbTextArea)
+    try:
+        hyperparameters = json.loads(experiment['hyperparameters'])['hyperparameters']
+    except KeyError as err:
+        raise GladosInternalError("Error generating configs - hyperparameters not found in experiment object") from err
+
+    configResult = generate_config_files(hyperparameters, dumbTextArea)
     if configResult is None:
         raise GladosInternalError("Error generating configs - somehow no config files were produced?")
     numExperimentsToRun = len(configResult) - 1
 
-    #Updating with run information
     expRef.update({"totalExperimentRuns": numExperimentsToRun + 1})
 
     try:
-        #Running the Experiment
         conduct_experiment(expId, expRef, trialExtraFile, trialResult, filepath, filetype, numExperimentsToRun, trialTimeout, keepLogs)
 
-        # Post Processing
         post_process_experiment(expId, experiment, scatterPlot, postProcess)
 
-        #Uploading Experiment Results
         upload_experiment_results(expId, trialExtraFile, postProcess)
     except ExperimentAbort as err:
         print(f'Experiment {expId} critical failure, not doing any result uploading or post processing')
         logging.exception(err)
     except Exception as err:
-        print(f'Uncaught exception "{err}," the GLADOS code needs to be changed to handle this in a cleaner manner')
+        print(f'Uncaught exception "{err}" while running an experiment the GLADOS code needs to be changed to handle this in a cleaner manner')
         logging.exception(err)
         raise err
     finally:
-        #Updating Firebase Object
         expRef.update({'finished': True, 'finishedAtEpochMillis': int(time.time() * 1000)})
         print(f'Exiting experiment {expId}')
         os.chdir('../..')

--- a/apps/backend/app.py
+++ b/apps/backend/app.py
@@ -50,6 +50,8 @@ CORS(flaskApp)
 MAX_WORKERS = 1
 runner = ProcessPoolExecutor(MAX_WORKERS)
 
+DB_COLLECTION_EXPERIMENTS = 'Experiments'
+
 
 ### FLASK API ENDPOINT
 @flaskApp.post("/experiment")
@@ -74,7 +76,7 @@ def handle_exceptions_from_run(data):
 
 def run_batch(data):
     print(f'Run_Batch starting with data {data}')
-    experiments = firebaseDb.collection('Experiments')
+    experiments = firebaseDb.collection(DB_COLLECTION_EXPERIMENTS)
 
     # Obtain most basic experiment info
     expId = data['experiment']['id']
@@ -90,7 +92,7 @@ def run_batch(data):
     keepLogs = experiment['keepLogs']
     trialTimeout = int(experiment['timeout'])
     scatterPlot = experiment['scatter']
-    dumbTextArea = experiment['consts']
+    dumbTextArea = experiment['dumbTextArea']
     postProcess = scatterPlot != ''
 
     #Downloading Experiment File
@@ -104,7 +106,7 @@ def run_batch(data):
 
     #Generating Configs from hyperparameters
     print(f"Generating configs and downloading to ExperimentFiles/{expId}/configFiles")
-    configResult = generate_config_files(json.loads(experiment['params'])['params'], dumbTextArea)
+    configResult = generate_config_files(json.loads(experiment['hyperparameters'])['hyperparameters'], dumbTextArea)
     if configResult is None:
         raise GladosInternalError("Error generating configs - somehow no config files were produced?")
     numExperimentsToRun = len(configResult) - 1

--- a/apps/frontend/components/NewExp.tsx
+++ b/apps/frontend/components/NewExp.tsx
@@ -66,7 +66,7 @@ const NewExp = ({ formState, setFormState, copyID, setCopyId, ...rest }) => {
 	const form = useForm({
 		// TODO make this follow the schema as closely as we can
 		initialValues: {
-			parameters: formList([] as any[]), // TODO type for parameters will remove the need for `any` here
+			hyperparameters: formList([] as any[]), // TODO type for parameters will remove the need for `any` here
 			name: '',
 			description: '',
 			trialExtraFile: '',
@@ -91,7 +91,7 @@ const NewExp = ({ formState, setFormState, copyID, setCopyId, ...rest }) => {
 					const expInfo = docSnap.data();
 					const hyperparameters = JSON.parse(expInfo['hyperparameters'])['hyperparameters'];
 					form.setValues({
-						parameters: formList(hyperparameters),
+						hyperparameters: formList(hyperparameters),
 						name: expInfo['name'],
 						description: expInfo['description'],
 						trialExtraFile: expInfo['trialExtraFile'],
@@ -116,7 +116,7 @@ const NewExp = ({ formState, setFormState, copyID, setCopyId, ...rest }) => {
 	}, [copyID]); // TODO adding form or setCopyId causes render loop?
 
 
-	const fields = form.values.parameters.map(({ type, ...rest }, index) => {
+	const fields = form.values.hyperparameters.map(({ type, ...rest }, index) => {
 		return <Parameter key = {index} form={form} type={type} index={index} {...rest} />;
 	});
 

--- a/apps/frontend/components/Parameter.tsx
+++ b/apps/frontend/components/Parameter.tsx
@@ -30,13 +30,13 @@ const Parameter = ({ form, type, index, ...rest }) => {
 							type='text'
 							placeholder='name'
 							className='block w-full rounded-l-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm'
-							{...form.getListInputProps('parameters', index, 'name')}
+							{...form.getListInputProps('hyperparameters', index, 'name')}
 							required
 						/>
 						<Component form={form} type={type} index={index} {...rest} />
 						<ActionIcon
 							color='red'
-							onClick={() => form.removeListItem('parameters', index)}
+							onClick={() => form.removeListItem('hyperparameters', index)}
 							className='ml-2'
 						>
 							<Trash/>
@@ -59,7 +59,7 @@ const NumberParam = ({ form, type, index, ...rest }) => {
 						placeholder={`${label}`}
 						className='block w-full last-of-type:rounded-r-md border-gray-300 shadow-sm focus:border-blue-500 sm:text-sm'
 						required
-						{...form.getListInputProps('parameters', index, label)}
+						{...form.getListInputProps('hyperparameters', index, label)}
 					/>
 				);
 			})}
@@ -73,7 +73,7 @@ const BoolParam = ({ form, type, index, ...rest }) => {
 			label={'value'}
 			onLabel={'True'}
 			offLabel={'False'}
-			{...form.getListInputProps('parameters', index, 'default')}
+			{...form.getListInputProps('hyperparameters', index, 'default')}
 		/>
 	);
 };
@@ -85,7 +85,7 @@ const StringParam = ({ form, type, index, ...rest }) => {
 				type='text'
 				placeholder={`${type} value`}
 				className='block w-full rounded-r-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm'
-				{...form.getListInputProps('parameters', index, 'default')}
+				{...form.getListInputProps('hyperparameters', index, 'default')}
 				required
 			/>
 		</>

--- a/apps/frontend/components/stepComponents/DispatchStep.tsx
+++ b/apps/frontend/components/stepComponents/DispatchStep.tsx
@@ -1,4 +1,4 @@
-import { Dropzone } from '@mantine/dropzone';
+import { Dropzone, DropzoneProps } from '@mantine/dropzone';
 import { submitExperiment, uploadExec } from '../../firebase/db';
 import { Text } from '@mantine/core';
 
@@ -6,13 +6,13 @@ import { useAuth } from '../../firebase/fbAuth';
 import { Upload, X, File, IconProps } from 'tabler-icons-react';
 
 export const DispatchStep = ({ id, form, ...props }) => {
-	const { userId, authService } = useAuth();
+	const { userId } = useAuth();
 
-	const onDropFile = async (file) => {
+	const onDropFile = (files: Parameters<DropzoneProps["onDrop"]>) => {
 		console.log('Submitting Experiment!!!');
-		submitExperiment(form.values, userId).then(async (expId) => {
+		submitExperiment(form.values, userId as string).then(async (expId) => {
 			console.log(`Uploading file for ${expId}`);
-			const uploadResponse = await uploadExec(expId, file[0]);
+			const uploadResponse = await uploadExec(expId, files[0]);
 			if (uploadResponse) {
 				console.log(`Handing experiment ${expId} to the backend`);
 				const response = await fetch(`/api/experiments/${expId}`, {
@@ -39,11 +39,12 @@ export const DispatchStep = ({ id, form, ...props }) => {
 		});
 	};
 
+	const MAXIMUM_SIZE_BYTES = 3 * 1024 ** 2;
 	return (
 		<Dropzone
-			onDrop={onDropFile}
+			onDrop={onDropFile as any}
 			onReject={(file) => console.log('NOPE, file rejected', file)}
-			maxSize={3 * 1024 ** 2}
+			maxSize={MAXIMUM_SIZE_BYTES}
 			className='flex-1 flex flex-col justify-center m-4 items-center'
 			accept={{
 				'text/plain': ['.py'],
@@ -62,16 +63,16 @@ const dropzoneKids = (status) => {
 			<UploadIcon status={status} />
 			<div>
 				<Text size='xl' inline>
-                    Upload your project executable.
+					Upload your project executable.
 				</Text>
 				<Text size='sm' color='dimmed' inline mt={7}>
-                    Let%apos;s revolutionize science!
+					Let{"'"}s revolutionize science!
 				</Text>
 			</div>
 		</div>;
 };
 interface UploadIconProps extends IconProps {
-    status
+	status
 }
 
 const UploadIcon: React.FC<UploadIconProps> = ({ status }) => {

--- a/apps/frontend/components/stepComponents/ParamStep.tsx
+++ b/apps/frontend/components/stepComponents/ParamStep.tsx
@@ -20,7 +20,7 @@ export const ParamStep = ({ form, ...props }) => {
 									key={`addNew_${type}`}
 									className='-ml-px relative items-center flex-1 px-6 py-2 last:rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:border-blue-500'
 									onClick={() =>
-										form.addListItem('parameters', {
+										form.addListItem('hyperparameters', {
 											name: '',
 											default: '',
 											...((type === 'integer' || type === 'float') && {
@@ -42,7 +42,7 @@ export const ParamStep = ({ form, ...props }) => {
 				<div className={'flex-0 p-4 h-full grow-0'}>
 					<DragDropContext
 						onDragEnd={({ destination, source }) => {
-							form.reorderListItem('parameters', {
+							form.reorderListItem('hyperparameters', {
 								from: source.index,
 								to: destination.index,
 							});

--- a/apps/frontend/firebase/db.ts
+++ b/apps/frontend/firebase/db.ts
@@ -18,15 +18,15 @@ export type FirebaseUserId = FirebaseId;
 export type ExperimentDocumentId = FirebaseDocumentId;
 
 export const submitExperiment = async (values: Partial<ExperimentData>, userId: FirebaseUserId): Promise<FirebaseId> => {
-	const newExperiment = doc(experiments, undefined);
+	const newExperimentDocument = doc(experiments);
 	console.log('Experiment submitted. Values:', values);
-	setDoc(newExperiment, {
+	setDoc(newExperimentDocument, {
 		creator: userId,
 		name: values.name,
 		description: values.description,
 		verbose: values.verbose,
 		workers: values.workers,
-		expId: newExperiment.id,
+		expId: newExperimentDocument.id,
 		trialExtraFile: values.trialExtraFile,
 		trialResult: values.trialResult,
 		timeout: values.timeout,
@@ -43,8 +43,8 @@ export const submitExperiment = async (values: Partial<ExperimentData>, userId: 
 		estimatedTotalTimeMinutes: 0,
 		expToRun: 0,
 	});
-	console.log(`Created Experiment: ${newExperiment.id}`);
-	return newExperiment.id;
+	console.log(`Created Experiment: ${newExperimentDocument.id}`);
+	return newExperimentDocument.id;
 };
 
 

--- a/apps/frontend/firebase/db.ts
+++ b/apps/frontend/firebase/db.ts
@@ -1,22 +1,31 @@
 import { firebaseApp } from './firebaseClient';
-import { getDoc, getFirestore, updateDoc } from 'firebase/firestore';
+import { getFirestore, updateDoc } from 'firebase/firestore';
 import { collection, setDoc, doc, query, where, onSnapshot } from 'firebase/firestore';
 import { getDownloadURL, getStorage, ref, uploadBytes } from 'firebase/storage';
+import { ExperimentData } from './db_types';
+
+export const DB_COLLECTION_EXPERIMENTS = 'Experiments';
 
 // Initialize Cloud Firestore and get a reference to the service
 const db = getFirestore(firebaseApp);
 const storage = getStorage(firebaseApp);
-const experiments = collection(db, 'Experiments');
+const experiments = collection(db, DB_COLLECTION_EXPERIMENTS);
 
-export const submitExperiment = async (values, userId) => {
-	const newExperiment = doc(experiments);
+export type FirebaseId = string;
+export type FirebaseDocumentId = FirebaseId;
+export type FirebaseUserId = FirebaseId;
+
+export type ExperimentDocumentId = FirebaseDocumentId;
+
+export const submitExperiment = async (values: Partial<ExperimentData>, userId: FirebaseUserId): Promise<FirebaseId> => {
+	const newExperiment = doc(experiments, undefined);
 	console.log('Experiment submitted. Values:', values);
 	setDoc(newExperiment, {
 		creator: userId,
 		name: values.name,
 		description: values.description,
 		verbose: values.verbose,
-		workers: values.nWorkers,
+		workers: values.workers,
 		expId: newExperiment.id,
 		trialExtraFile: values.trialExtraFile,
 		trialResult: values.trialResult,
@@ -25,10 +34,10 @@ export const submitExperiment = async (values, userId) => {
 		scatter: values.scatter,
 		scatterIndVar: values.scatterIndVar,
 		scatterDepVar: values.scatterDepVar,
-		consts: values.dumbTextArea,
+		dumbTextArea: values.dumbTextArea,
 		created: Date.now(),
-		params: JSON.stringify({
-			params: values.parameters,
+		hyperparameters: JSON.stringify({
+			hyperparameters: values.hyperparameters,
 		}),
 		finished: false,
 		estimatedTotalTimeMinutes: 0,
@@ -39,10 +48,10 @@ export const submitExperiment = async (values, userId) => {
 };
 
 
-export const uploadExec = async (id, file) => {
+export const uploadExec = async (id: ExperimentDocumentId, file) => {
 	const fileRef = ref(storage, `experiment${id}`);
 	return await uploadBytes(fileRef, file).then((snapshot) => {
-		const experimentRef = doc(db, 'Experiments', id);
+		const experimentRef = doc(db, DB_COLLECTION_EXPERIMENTS, id);
 		updateDoc(experimentRef, {
 			file: `experiment${id}`,
 		}).then(() => {
@@ -56,17 +65,7 @@ export const uploadExec = async (id, file) => {
 	});
 };
 
-export const getDocById = (id) => {
-	getDoc(doc(db, 'Experiments', id)).then((docSnap) => {
-		if (docSnap.exists()) {
-			return docSnap.data();
-		} else {
-			console.log('No such document!');
-		}
-	});
-};
-
-export const downloadExp = (event) => {
+export const downloadExperimentResults = (event) => {
 	const id = event.target.getAttribute('data-id');
 	console.log(`Downloading results for ${id}`);
 	const fileRef = ref(storage, `results/result${id}.csv`);
@@ -80,9 +79,9 @@ export const downloadExp = (event) => {
 	}).catch((error) => console.log('Get download url for exp error: ', error));
 };
 
-export const downloadExpZip = (event) => {
+export const downloadExperimentProjectZip = (event) => {
 	const id = event.target.getAttribute('data-id');
-	console.log(`Downloading results for ${id}`);
+	console.log(`Downloading project zip for ${id}`);
 	const fileRef = ref(storage, `results/result${id}.zip`);
 	getDownloadURL(fileRef).then((url) => {
 		const anchor = document.createElement('a');
@@ -94,19 +93,27 @@ export const downloadExpZip = (event) => {
 	}).catch((error) => console.log('Upload download url for zip error: ', error));
 };
 
-export const subscribeToExp = (id, callback) => {
-	const unsubscribe = onSnapshot(doc(db, 'Experiments', id), (doc) => {
+export interface ExperimentSubscribeCallback {
+	(data: Partial<ExperimentData>): any;
+}
+
+export const subscribeToExp = (id: ExperimentDocumentId, callback: ExperimentSubscribeCallback) => {
+	const unsubscribe = onSnapshot(doc(db, DB_COLLECTION_EXPERIMENTS, id), (doc) => {
 		console.log(`exp ${id} data updated: `, doc.data());
-		callback(doc.data());
+		callback(doc.data() as Partial<ExperimentData>);
 	});
 	return unsubscribe;
 };
 
 
-export const listenToExperiments = (uid, callback) => {
+export interface MultipleExperimentSubscribeCallback {
+	(data: [Partial<ExperimentData>]): any;
+}
+
+export const listenToExperiments = (uid: FirebaseUserId, callback: MultipleExperimentSubscribeCallback) => {
 	const q = query(experiments, where('creator', '==', uid));
 	const unsubscribe = onSnapshot(q, (snapshot) => {
-		const result: unknown[] = [];
+		const result = [] as unknown as [Partial<ExperimentData>];
 		snapshot.forEach((doc) => result.push(doc.data()));
 		callback(result);
 	});

--- a/apps/frontend/firebase/db_types.ts
+++ b/apps/frontend/firebase/db_types.ts
@@ -1,0 +1,79 @@
+import { StorageReference } from 'firebase/storage';
+import { ExperimentDocumentId, FirebaseUserId } from './db';
+
+
+export type FileName = string;
+
+export type EpochMilliseconds = number;
+
+export interface HyperparametersCollection {
+    hyperparameters: [IntegerHyperparameter | FloatHyperparameter | StringHyperparameter | BooleanHyperparameter]
+}
+
+export enum HyperparameterTypes {
+    INTEGER = 'integer',
+    FLOAT = 'float',
+    STRING = 'string',
+    BOOLEAN = 'boolean',
+}
+
+// TODO this duplicates information in validators.ts (the Joi schemas), see https://github.com/AutomatingSciencePipeline/Monorepo/issues/114
+
+export interface GenericHyperparameter {
+    name: string;
+    type: HyperparameterTypes;
+}
+
+// TODO JS does not distinguish between integers and floats, so they end up being the same interface, do we want them to differ?
+export interface IntegerHyperparameter extends GenericHyperparameter {
+    min: number;
+    max: number;
+    step: number;
+    default: number;
+    type: HyperparameterTypes.INTEGER;
+}
+
+export interface FloatHyperparameter extends GenericHyperparameter {
+    min: number;
+    max: number;
+    step: number;
+    default: number;
+    type: HyperparameterTypes.FLOAT;
+}
+
+export interface BooleanHyperparameter extends GenericHyperparameter {
+    default: boolean;
+    type: HyperparameterTypes.BOOLEAN;
+}
+
+export interface StringHyperparameter extends GenericHyperparameter {
+    default: string;
+    type: HyperparameterTypes.STRING;
+}
+
+export interface ExperimentData {
+    creator: FirebaseUserId;
+    name: string;
+    description: string;
+    verbose: boolean;
+    workers: number;
+    expId: ExperimentDocumentId; // TODO do we want to ensure this doesn't get stored in fb itself?
+    trialExtraFile: FileName;
+    trialResult: FileName;
+    timeout: number;
+    keepLogs: boolean;
+    scatter: boolean;
+    scatterIndVar: string;
+    scatterDepVar: string;
+    dumbTextArea: string;
+    created: EpochMilliseconds;
+    hyperparameters: HyperparametersCollection;
+    finished: boolean;
+    estimatedTotalTimeMinutes: number;
+    expToRun: number; // TODO is this used?
+    file: StorageReference; // TODO rename to something more unique
+    finishedAtEpochMilliseconds: EpochMilliseconds;
+    passes: number;
+    fails: number;
+    totalExperimentRuns: number;
+}

--- a/apps/frontend/firebase/fbAuth.tsx
+++ b/apps/frontend/firebase/fbAuth.tsx
@@ -26,7 +26,7 @@ export interface AuthServiceType {
 
 export interface AuthContextType {
 	user: User | null;
-	userId: String | null;
+	userId: string | null;
 	authService: AuthServiceType;
 	loading: boolean;
 }

--- a/apps/frontend/pages/dashboard.tsx
+++ b/apps/frontend/pages/dashboard.tsx
@@ -1,6 +1,6 @@
 import NewExp, { FormStates } from '../components/NewExp';
 import { useAuth } from '../firebase/fbAuth';
-import { subscribeToExp, listenToExperiments, downloadExp, downloadExpZip } from '../firebase/db';
+import { subscribeToExp, listenToExperiments, downloadExperimentResults, downloadExperimentProjectZip } from '../firebase/db';
 import { Fragment, useState, useEffect } from 'react';
 import { Disclosure, Menu, Transition } from '@headlessui/react';
 import {
@@ -193,7 +193,7 @@ const ExpLog = ({ projectinit, setFormState, setCopyId }) => {
 				{project['finished'] == true ?
 					<button type= "button" data-id={project.expId}
 						className='inline-flex items-center justify-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 xl:w-full'
-						onClick={downloadExp}>
+						onClick={downloadExperimentResults}>
 						Download Results
 					</button> :
 					null
@@ -201,7 +201,7 @@ const ExpLog = ({ projectinit, setFormState, setCopyId }) => {
 				{project['finished'] == true && (project['trialExtraFile'] || project['scatter'] || project['keepLogs']) ?
 					<button type= "button" data-id={project.expId}
 						className='inline-flex items-center justify-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 xl:w-full'
-						onClick={downloadExpZip}>
+						onClick={downloadExperimentProjectZip}>
 						Download Project Zip
 					</button> :
 					null

--- a/apps/frontend/utils/validators.ts
+++ b/apps/frontend/utils/validators.ts
@@ -38,7 +38,7 @@ export const experimentSchema = Joi.object().keys({
 	description: Joi.string(),
 	verbose: Joi.boolean(),
 	parameters: Joi.array().items(intschema, floatschema, boolschema, strschema),
-	nWorkers: Joi.number().integer().required(),
+	workers: Joi.number().integer().required(),
 });
 
 export const signUpSchema = Joi.object().keys({

--- a/apps/frontend/utils/validators.ts
+++ b/apps/frontend/utils/validators.ts
@@ -37,7 +37,7 @@ export const experimentSchema = Joi.object().keys({
 	name: Joi.string().required(),
 	description: Joi.string(),
 	verbose: Joi.boolean(),
-	parameters: Joi.array().items(intschema, floatschema, boolschema, strschema),
+	hyperparameters: Joi.array().items(intschema, floatschema, boolschema, strschema),
 	workers: Joi.number().integer().required(),
 });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,11 @@ services:
     volumes:
         - ./apps/backend/ExperimentFiles:/app/ExperimentFiles
     ports:
+        # Exposed to the Host : Port inside the container Container https://docs.docker.com/compose/compose-file/compose-file-v3/#ports
         # TODO does this need to be exposed to host?
         - ${BACKEND_PORT}:${BACKEND_PORT}
     expose:
+        # Exposed to other containers in the same network https://docs.docker.com/compose/compose-file/compose-file-v3/#expose
         - "${BACKEND_PORT}"
 
   app-frontend:
@@ -37,9 +39,11 @@ services:
       FRONTEND_WEBSERVER_PORT: ${FRONTEND_WEBSERVER_PORT}
     working_dir: /app
     ports:
+      # Exposed to the Host : Port inside the container Container https://docs.docker.com/compose/compose-file/compose-file-v3/#ports
       - ${FRONTEND_WEBSERVER_PORT}:${FRONTEND_WEBSERVER_PORT}
       - 80:${FRONTEND_WEBSERVER_PORT}
     expose:
+      # Exposed to other containers in the same network https://docs.docker.com/compose/compose-file/compose-file-v3/#expose
       - "${FRONTEND_WEBSERVER_PORT}"
       - "80"
 


### PR DESCRIPTION
Rename `consts` to `dumbTextArea`. Rename `params` to `hyperparameters`. Rename `nWorkers` to `workers`. Start using more types in the frontend db methods.
