### PR TITLE
Fix dropzone missing contents

### DIFF
--- a/apps/frontend/components/flows/AddExperiment/stepComponents/DispatchStep.tsx
+++ b/apps/frontend/components/flows/AddExperiment/stepComponents/DispatchStep.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 
 const SUPPORTED_FILE_TYPES = {
 	'text/plain': ['.py'],
+	'text/x-python': ['.py'],
 	'application/java-archive': ['.jar'],
 };
 
@@ -54,7 +55,8 @@ export const DispatchStep = ({ id, form, ...props }) => {
 			onDrop={onDropFile}
 			onReject={(rejections) => {
 				console.log('File rejection details', rejections);
-				alert(`Rejected: ${rejections[0]?.errors[0]?.message}\nCheck the console for more details.`);
+				const uploadedType = rejections[0]?.file?.type;
+				alert(`Rejected:\n${rejections[0]?.errors[0]?.message}\nYour file was of type: ${uploadedType ? uploadedType : 'Unknown'}\nCheck the console for more details.`);
 			}}
 			maxSize={MAXIMUM_SIZE_BYTES}
 			maxFiles={1}
@@ -85,7 +87,7 @@ export const DispatchStep = ({ id, form, ...props }) => {
 						Drag-and-drop, or click here to open a file picker.
 					</Text>
 					<Text size="sm" color="dimmed" inline mt={7}>
-						Supported: {Object.values(SUPPORTED_FILE_TYPES).join(', ')}
+						Supported: {[...new Set(Object.values(SUPPORTED_FILE_TYPES).flat())].join(', ')}
 					</Text>
 				</div>
 			</Group>

--- a/apps/frontend/components/flows/AddExperiment/stepComponents/DispatchStep.tsx
+++ b/apps/frontend/components/flows/AddExperiment/stepComponents/DispatchStep.tsx
@@ -1,17 +1,25 @@
 import { Dropzone, DropzoneProps } from '@mantine/dropzone';
 import { submitExperiment, uploadExec } from '../../../../firebase/db';
-import { Text } from '@mantine/core';
+import { Group, Text } from '@mantine/core';
 
 import { useAuth } from '../../../../firebase/fbAuth';
-import { Upload, X, File, IconProps } from 'tabler-icons-react';
+import { Upload, FileCode } from 'tabler-icons-react';
+import { useState } from 'react';
+
+const SUPPORTED_FILE_TYPES = {
+	'text/plain': ['.py'],
+	'application/java-archive': ['.jar'],
+};
 
 export const DispatchStep = ({ id, form, ...props }) => {
 	const { userId } = useAuth();
+	const [loading, setLoading] = useState<boolean>(false);
 
-	const onDropFile = (files: Parameters<DropzoneProps["onDrop"]>) => {
-		console.log('Submitting Experiment!!!');
+	const onDropFile = (files: Parameters<DropzoneProps['onDrop']>[0]) => {
+		setLoading(true);
+		console.log('Submitting Experiment');
 		submitExperiment(form.values, userId as string).then(async (expId) => {
-			console.log(`Uploading file for ${expId}`);
+			console.log(`Uploading file for ${expId}:`, files);
 			const uploadResponse = await uploadExec(expId, files[0]);
 			if (uploadResponse) {
 				console.log(`Handing experiment ${expId} to the backend`);
@@ -25,61 +33,62 @@ export const DispatchStep = ({ id, form, ...props }) => {
 					console.log('Response from backend received', response);
 				} else {
 					const responseText = await response.text();
-					alert(`Upload failed: ${response.status}: ${responseText}`);
 					console.log('Upload failed', responseText, response);
 					throw new Error(`Upload failed: ${response.status}: ${responseText}`);
 				}
 			} else {
-				alert('Failed to upload experiment file to the backend server, is it running?');
-				throw new Error('Upload failed');
+				throw new Error('Failed to upload experiment file to the backend server, is it running?');
 			}
 		}).catch((error) => {
 			console.log('Error uploading experiment: ', error);
 			alert(`Error uploading experiment: ${error.message}`);
+		}).finally(() => {
+			setLoading(false);
 		});
 	};
 
 	const MAXIMUM_SIZE_BYTES = 3 * 1024 ** 2;
+
 	return (
 		<Dropzone
-			onDrop={onDropFile as any}
-			onReject={(file) => console.log('NOPE, file rejected', file)}
-			maxSize={MAXIMUM_SIZE_BYTES}
-			className='flex-1 flex flex-col justify-center m-4 items-center'
-			accept={{
-				'text/plain': ['.py'],
-				'application/java-archive': ['.jar'],
+			onDrop={onDropFile}
+			onReject={(rejections) => {
+				console.log('File rejection details', rejections);
+				alert(`Rejected: ${rejections[0]?.errors[0]?.message}\nCheck the console for more details.`);
 			}}
+			maxSize={MAXIMUM_SIZE_BYTES}
+			maxFiles={1}
+			className='flex-1 flex flex-col justify-center m-4 items-center'
+			loading={loading}
+			accept={Object.keys(SUPPORTED_FILE_TYPES)}
 		>
-			<>{(status) => dropzoneKids(status)}</>
+			<Group position="center" spacing="xl" style={{ minHeight: 220, pointerEvents: 'none' }}>
+				<Dropzone.Accept>
+					<Upload size={80} />
+				</Dropzone.Accept>
+				<Dropzone.Reject>
+					{/* For some reason (seems to be happening on React itself's side?) the dropzone is claiming to reject files even if the file's mime
+					type is included in the accept list we pass it. Works for images, when changed to be images, but not our stuff. Check browser console
+					and you can see that the file object's type really does match what we have in our list!*/}
+					<Upload size={80} />
+					{/* <X size={80} /> */}
+				</Dropzone.Reject>
+				<Dropzone.Idle>
+					<FileCode size={80} />
+				</Dropzone.Idle>
+
+				<div>
+					<Text size="xl" inline>
+						Upload your project executable.
+					</Text>
+					<Text size="sm" color="dimmed" inline mt={7}>
+						Drag-and-drop, or click here to open a file picker.
+					</Text>
+					<Text size="sm" color="dimmed" inline mt={7}>
+						Supported: {Object.values(SUPPORTED_FILE_TYPES).join(', ')}
+					</Text>
+				</div>
+			</Group>
 		</Dropzone>
 	);
-};
-
-const dropzoneKids = (status) => {
-	return (status.accepted) ?
-		<UploadIcon className={'bg-green-500'} status={status} /> :
-		<div className={'flex flex-col justify-center items-center space-y-6'}>
-			<UploadIcon status={status} />
-			<div>
-				<Text size='xl' inline>
-					Upload your project executable.
-				</Text>
-				<Text size='sm' color='dimmed' inline mt={7}>
-					Let{"'"}s revolutionize science!
-				</Text>
-			</div>
-		</div>;
-};
-interface UploadIconProps extends IconProps {
-	status
-}
-
-const UploadIcon: React.FC<UploadIconProps> = ({ status }) => {
-	if (status.accepted) {
-		return <Upload size={80} />;
-	} else if (status.rejected) {
-		return <X size={80} />;
-	}
-	return <File size={80} />;
 };

--- a/apps/frontend/components/flows/AddExperiment/stepComponents/DispatchStep.tsx
+++ b/apps/frontend/components/flows/AddExperiment/stepComponents/DispatchStep.tsx
@@ -64,17 +64,17 @@ export const DispatchStep = ({ id, form, ...props }) => {
 		>
 			<Group position="center" spacing="xl" style={{ minHeight: 220, pointerEvents: 'none' }}>
 				<Dropzone.Accept>
-					<Upload size={80} />
+					<Upload size={80} strokeWidth={1}/>
 				</Dropzone.Accept>
 				<Dropzone.Reject>
 					{/* For some reason (seems to be happening on React itself's side?) the dropzone is claiming to reject files even if the file's mime
 					type is included in the accept list we pass it. Works for images, when changed to be images, but not our stuff. Check browser console
 					and you can see that the file object's type really does match what we have in our list!*/}
-					<Upload size={80} />
-					{/* <X size={80} /> */}
+					<Upload size={80} strokeWidth={1}/>
+					{/* <X size={80} strokeWidth={1}/> */}
 				</Dropzone.Reject>
 				<Dropzone.Idle>
-					<FileCode size={80} />
+					<FileCode size={80} strokeWidth={1}/>
 				</Dropzone.Idle>
 
 				<div>

--- a/apps/frontend/components/flows/ViewExperiment/ExperimentListing.tsx
+++ b/apps/frontend/components/flows/ViewExperiment/ExperimentListing.tsx
@@ -98,14 +98,16 @@ export const ExperimentListing = ({ projectinit, onCopyExperiment, onDownloadRes
 			</div>
 			<div className='hidden sm:flex flex-col flex-shrink-0 items-end space-y-3'>
 				<p className='flex items-center space-x-4'>
-					{project['finished'] ?
-						<span className='font-mono'>Experiment Completed</span> :
-						(experimentInProgress ?
+					{project.finished ?
+						(project.fails <= 1 && (project?.passes ?? 0) == 0 ?
+							<span className='font-mono text-red-500'>Experiment Aborted</span> :
+							<span className='font-mono'>Experiment Completed</span>
+						) : (experimentInProgress ?
 							<span className='font-mono text-blue-500'>Experiment In Progress</span> :
 							<span className='font-mono text-gray-500'>Experiment Awaiting Start</span>)
 					}
 				</p>
-				{project['finished'] || experimentInProgress ?
+				{project.finished || experimentInProgress ?
 					<p className='flex items-center space-x-4'>
 						<span className={`font-mono ${project['fails'] ? 'text-red-500' : ''}`}>FAILS: {project['fails'] ?? 0}</span>
 						<span className='font-mono'>SUCCESSES: {project['passes'] ?? 0}</span>

--- a/apps/frontend/firebase/db.ts
+++ b/apps/frontend/firebase/db.ts
@@ -52,6 +52,7 @@ export const submitExperiment = async (values: Partial<ExperimentData>, userId: 
 export const uploadExec = async (id: ExperimentDocumentId, file) => {
 	const fileRef = ref(storage, `experiment${id}`);
 	return await uploadBytes(fileRef, file).then((snapshot) => {
+		console.log('Uploaded file. Updating doc...');
 		const experimentRef = doc(db, DB_COLLECTION_EXPERIMENTS, id);
 		updateDoc(experimentRef, {
 			file: `experiment${id}`,

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
(they were lost when we updated Mantine). Make dropzone enter loading mode when files are being processed. Clean up onDrop typescript type. Resolves that old react warning about functions as props.