### PR TITLE
Experiments can be Archived

### DIFF
--- a/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
+++ b/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
@@ -290,7 +290,7 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 					</div>
 				)}
 				{
-					project.status != 'COMPLETED' ?
+					project.status != 'COMPLETED' && project.status != 'ARCHIVED' ?
 						<button type="button"
 								className='inline-flex items-center justify-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 xl:w-full'
 								onClick={() => {
@@ -356,7 +356,7 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 				}
 
 				{
-					project.status != 'COMPLETED' ?
+					project.status != 'COMPLETED' && project.status != 'ARCHIVED' ?
 						(project.creator == session?.user?.id! && project.status != 'CANCELLED' ?
 							<button
 								type="button"
@@ -475,7 +475,7 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 								<p>(Calculating total experiment runs...)</p>
 						) : null)
 				}
-				{project.status != 'COMPLETED' ?
+				{project.status != 'COMPLETED' && project.status != 'ARCHIVED' ?
 					(<p className='flex text-centertext-gray-500 text-sm space-x-2'>
 						<span>Uploaded at {new Date(Number(project['created'])).toLocaleString()}</span>
 					</p>) :
@@ -485,7 +485,7 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 							</p>) : null
 					)
 				}
-				{project.status != 'COMPLETED' ?
+				{project.status != 'COMPLETED' && project.status != 'ARCHIVED' ?
 					(project['startedAtEpochMillis'] && project.status != 'CANCELLED' ?
 						<p className='flex text-center text-gray-500 text-sm space-x-2'>
 							<span>Started at {new Date(project['startedAtEpochMillis']).toLocaleString()}</span>

--- a/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
+++ b/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
@@ -148,7 +148,7 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 				<div className="inline-flex items-center justify-center cursor-pointer hover:opacity-80">
 					{isClosed ? (
 						<span className='text-sm font-medium' style={{display: 'flex', alignItems: 'center'}}>
-							{project.status == 'COMPLETED' ?
+							{project.status == 'COMPLETED' || project.status == 'ARCHIVED' ?
 								(<ChevronRightIcon onClick={() => setClose(!isClosed)} className="h-5 w-5 text-gray-400" aria-hidden="true"/>)
 								: null}
 							{isEditing ? (
@@ -180,8 +180,8 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 						</span>
 						) :
 						(<span className='text-sm font-medium' style={{display: 'flex', alignItems: 'center'}}>
-							{project.status == 'COMPLETED' ?
-								(<ChevronDownIcon onClick={() => setClose(!isClosed)} className="h-5 w-5 text-gray-400 -translate-y-2"  aria-hidden="true"/>)
+							{project.status == 'COMPLETED' || project.status == 'ARCHIVED' ?
+								(<ChevronDownIcon onClick={() => setClose(!isClosed)} className="h-5 w-5 text-gray-400 translate-y-4"  aria-hidden="true"/>)
 								: null}
 						</span>)
 					}

--- a/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
+++ b/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
@@ -3,13 +3,7 @@ import { useEffect, useState } from 'react';
 import { ExperimentData } from '../../../../lib/db_types';
 import { MdEdit } from 'react-icons/md';
 import Chart from './Chart';
-import {
-	addShareLink,
-	unfollowExperiment,
-	updateExperimentNameById,
-	cancelExperimentById,
-	updateExperimentArchiveStatusById
-} from '../../../../lib/mongodb_funcs';
+import { addShareLink, unfollowExperiment, updateExperimentNameById, cancelExperimentById, updateExperimentArchiveStatusById } from '../../../../lib/mongodb_funcs';
 import toast from 'react-hot-toast';
 import { useSession } from 'next-auth/react';
 import { CheckIcon, ChevronRightIcon, ShareIcon, FolderArrowDownIcon, DocumentDuplicateIcon, ChartBarIcon, XMarkIcon, MinusIcon, ExclamationTriangleIcon, DocumentCheckIcon, ChevronDownIcon, ArchiveBoxIcon } from '@heroicons/react/24/solid';

--- a/apps/frontend/app/dashboard/page.tsx
+++ b/apps/frontend/app/dashboard/page.tsx
@@ -905,11 +905,7 @@ const ExperimentList = ({ experiments, onCopyExperiment, onDeleteExperiment, sea
 					if (!includeCompleted && project.finished) {
 						return null;
 					}
-					const projectFinishedDate = new Date(project['finishedAtEpochMillis'] || 0);
-					const oneHourMilliseconds = 1000 * 60 * 60;
-					const twoWeeksMilliseconds = oneHourMilliseconds * 24 * 14;
-					const projectIsArchived = projectFinishedDate.getTime() + twoWeeksMilliseconds < Date.now();
-					if (!includeArchived && projectIsArchived) {
+					if (!includeArchived && (project.status == 'ARCHIVED')) {
 						return null;
 					}
 					return (

--- a/apps/frontend/app/dashboard/page.tsx
+++ b/apps/frontend/app/dashboard/page.tsx
@@ -783,7 +783,7 @@ const ExperimentList = ({ experiments, onCopyExperiment, onDeleteExperiment, sea
 	};
 
 	const [includeCompleted, setIncludeCompleted] = useState(true);
-	const [includeArchived, setIncludeArchived] = useState(true);
+	const [includeArchived, setIncludeArchived] = useState(false);
 
 	return (<div className='bg-white lg:min-w-0 lg:flex-1'>
 		<div className='pl-4 pr-6 pt-4 pb-4 border-b border-t border-gray-200 sm:pl-6 lg:pl-8 xl:pl-6 xl:pt-6 xl:border-t-0'>
@@ -902,7 +902,7 @@ const ExperimentList = ({ experiments, onCopyExperiment, onDeleteExperiment, sea
 					}
 					return project.name.toLowerCase().includes(searchTerm.toLowerCase());
 				}).map((project: ExperimentData) => {
-					if (!includeCompleted && project.finished) {
+					if (!includeCompleted && project.finished && (project.status == 'COMPLETED')) {
 						return null;
 					}
 					if (!includeArchived && (project.status == 'ARCHIVED')) {

--- a/apps/frontend/lib/mongodb_funcs.ts
+++ b/apps/frontend/lib/mongodb_funcs.ts
@@ -97,6 +97,20 @@ export async function updateExperimentNameById(expId: string, newExpName: string
     return Promise.resolve();
 }
 
+export async function updateExperimentArchiveStatusById(expId: string, newStatus: string) {
+    'use server';
+    const client = await clientPromise;
+    const collection = client.db(DB_NAME).collection(COLLECTION_EXPERIMENTS);
+
+    const experiment = await collection.updateOne({ '_id': new ObjectId(expId) }, { $set: { 'status': newStatus } });
+
+    if (experiment.modifiedCount == 0) {
+        return Promise.reject(`Could not update document with id: ${expId}`);
+    }
+
+    return Promise.resolve();
+}
+
 export async function refreshFileTimestamp(fileId: string) {
     'use server';
     const client = await clientPromise;


### PR DESCRIPTION
There is an 'Archive Experiment' button above the delete button. Being archived is a new status an experiment can be, in addition to completed, aborted and cancelled.
When the button is clicked, the experiment changes from 'Completed' to 'Archived'. This is helpful when filtering out experiments; archived experiments are filtered out by default, so they will be hidden from the user unless they want to see them.