### PR TITLE
Improved how Editing Experiment Names works

### DIFF
--- a/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
+++ b/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
@@ -144,8 +144,8 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 									<input
 										type="text"
 										style={{
-											width: `${Math.min(Math.max(projectName.length, 40), 80)}ch`,
-											transition: 'width 0.2s ease'
+											width: `${Math.min(Math.max(projectName.length, 40), 60)}ch`,
+											transition: 'width 0.1s ease'
 										}}
 										value={projectName}
 										onChange={(e) => setProjectName(e.target.value)}
@@ -186,8 +186,8 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 									<input
 										type="text"
 										style={{
-											width: `${Math.min(Math.max(projectName.length, 40), 80)}ch`,
-											transition: 'width 0.2s ease'
+											width: `${Math.min(Math.max(projectName.length, 40), 60)}ch`,
+											transition: 'width 0.1s ease'
 										}}
 										value={projectName}
 										onChange={(e) => setProjectName(e.target.value)}

--- a/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
+++ b/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
@@ -143,13 +143,15 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 								<>
 									<input
 										type="text"
-										style={{width: `60ch`}}
+										style={{
+											width: `${Math.min(Math.max(projectName.length, 40), 80)}ch`,
+											transition: 'width 0.2s ease'
+										}}
 										value={projectName}
 										onChange={(e) => setProjectName(e.target.value)}
 										onKeyUp={handleKeyUp}
 									/>
-									<CheckIcon className="w-10 h-5 text-green-500 cursor-pointer"
-											   onClick={() => handleSave(projectName)}/>
+									<CheckIcon className="w-10 h-5 text-green-500 cursor-pointer" onClick={() => handleSave(projectName)}/>
 									<XMarkIcon className="w-5 h-5 text-red-500 cursor-pointer" onClick={handleCancel}/>
 								</>
 							) : (
@@ -183,7 +185,10 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 								<>
 									<input
 										type="text"
-										style={{width: `60ch`}}
+										style={{
+											width: `${Math.min(Math.max(projectName.length, 40), 80)}ch`,
+											transition: 'width 0.2s ease'
+										}}
 										value={projectName}
 										onChange={(e) => setProjectName(e.target.value)}
 										onKeyUp={handleKeyUp}
@@ -207,7 +212,7 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 								</>
 							)}
 						</span>
-					</div> :
+						</div> :
 					null
 				}
 

--- a/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
+++ b/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
@@ -212,7 +212,7 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 								</>
 							)}
 						</span>
-						</div> :
+					</div> :
 					null
 				}
 

--- a/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
+++ b/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
@@ -144,7 +144,7 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 									<input
 										type="text"
 										style={{
-											width: `${Math.min(Math.max(projectName.length, 40), 60)}ch`,
+											width: `${Math.min(Math.max(projectName.length, 30), 65)}ch`,
 											transition: 'width 0.1s ease'
 										}}
 										value={projectName}
@@ -186,7 +186,7 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 									<input
 										type="text"
 										style={{
-											width: `${Math.min(Math.max(projectName.length, 40), 60)}ch`,
+											width: `${Math.min(Math.max(projectName.length, 30), 65)}ch`,
 											transition: 'width 0.1s ease'
 										}}
 										value={projectName}

--- a/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
+++ b/apps/frontend/app/components/flows/ViewExperiment/ExperimentListing.tsx
@@ -143,6 +143,7 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 								<>
 									<input
 										type="text"
+										style={{width: `60ch`}}
 										value={projectName}
 										onChange={(e) => setProjectName(e.target.value)}
 										onKeyUp={handleKeyUp}
@@ -182,6 +183,7 @@ export const ExperimentListing = ({ projectData: projectData, onCopyExperiment, 
 								<>
 									<input
 										type="text"
+										style={{width: `60ch`}}
 										value={projectName}
 										onChange={(e) => setProjectName(e.target.value)}
 										onKeyUp={handleKeyUp}


### PR DESCRIPTION
Now the edit name bar is by default larger, and can get larger if the experiment name reaches to be long enough. Still has a max length, but it is far longer than before now.