### PR TITLE
Refactor/#596 bitnami image migration

### DIFF
--- a/helm_packages/mongodb-helm/tilt/values.yaml
+++ b/helm_packages/mongodb-helm/tilt/values.yaml
@@ -1,6 +1,11 @@
 # values.yaml
 architecture: replicaset
 
+image: 
+  registry: docker.io 
+  repository: bitnamilegacy/mongodb 
+  tag: 8.0.13
+
 replicaSet:
   enabled: true
   replicas: 3 # Set the number of replicas

--- a/helm_packages/mongodb-helm/values.yaml
+++ b/helm_packages/mongodb-helm/values.yaml
@@ -1,6 +1,11 @@
 # values.yaml
 architecture: replicaset
 
+image: 
+  registry: docker.io 
+  repository: bitnamilegacy/mongodb 
+  tag: 8.0.13
+
 replicaSet:
   enabled: true
   replicas: 3 # Set the number of replicas


### PR DESCRIPTION
This adds an image substitution change to the yaml file in order to pull from bitnami legacy instead of bitnami, which is being removed by the provider.