### PR TITLE
MongoDB Security Patch

### DIFF
--- a/apps/backend/job-runner.yaml
+++ b/apps/backend/job-runner.yaml
@@ -15,6 +15,11 @@ spec:
         imagePullPolicy: Always
         command: []
         env:
+        - name: MONGODB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: secret-env
+              key: MONGODB_PORT
         - name: BACKEND_PORT
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
I recommend testing this - it worked when I tested it after I removed `MONGODB_PORT`, but it seems it didn't work for others.

**We should deploy ASAP after this gets merged.**