### PR TITLE
Adds min value to step to prevent freeze up

### DIFF
--- a/apps/frontend/app/components/Parameter.tsx
+++ b/apps/frontend/app/components/Parameter.tsx
@@ -228,6 +228,7 @@ const NumberParam = ({ form, type, index, ...rest }) => {
 								className='block w-full last-of-type:rounded-r-md border-gray-300 shadow-sm focus:border-blue-500 sm:text-sm'
 								{...form.getInputProps(`hyperparameters.${index}.${label}`)}
 								data-tip={tooltipText}
+								min={label == 'step'? 0 : Number.NEGATIVE_INFINITY}
 							/>
 						</Tooltip>
 					</Fragment>


### PR DESCRIPTION
Addresses freeze up bug by:
- Since min values always have to be less than the max in the first place (so negative step values were never supported), simply added minimum value tag that prevents step for number params (float & int) from going below 0, which is the defined min step value elsewhere in the code.
