### PR TITLE
Added necessary parameter lines to user-defined constants field

### DIFF
--- a/example_experiments/python/addNumsWithConstants.py
+++ b/example_experiments/python/addNumsWithConstants.py
@@ -27,7 +27,6 @@ y, default: 1, min: 1, max: 10, step: 1
 
 Paste into the User-Defined Contants field:
 
-[DEFAULT]
 x={x}
 y={y}
 [const]


### PR DESCRIPTION
Original experiment example was missing lines- would not  run the experiment without adding x y parameters with curly braces: refer to "User Defined Constant Tab" section in 

https://automatingsciencepipeline.github.io/Monorepo/tutorial/usage/ 

Likely some kind of deprecation occurred from previous year work.