### PR TITLE
Improve Setup Documentation

### DIFF
--- a/dev-install.sh
+++ b/dev-install.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-echo NOTE: This is NOT the setup script the most recent GLADOS team used.
+echo ⚠️WARNING⚠️
+echo This is NOT the setup script the most recent GLADOS team used.
+echo
 echo We recommend running /.devcontainer/post-start.sh instead.
-echo This script may break things when run. We have preserved the original script, and you may run it by opening the file and removing the first "exit".
-exit
+echo This script may break things when run. We have preserved it and you may run it by opening the file and removing the first "exit".
+echo However, this is highly inadvisable. 
+exit 1
 
 
 # You need Bash installed to run this script. Follow the setup directions here: https://github.com/AutomatingSciencePipeline/Monorepo/wiki

--- a/dev-install.sh
+++ b/dev-install.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+echo NOTE: This is NOT the setup script the most recent GLADOS team used.
+echo We recommend running /.devcontainer/post-start.sh instead.
+echo This script may break things when run. We have preserved the original script, and you may run it by opening the file and removing the first "exit".
+exit
+
+
 # You need Bash installed to run this script. Follow the setup directions here: https://github.com/AutomatingSciencePipeline/Monorepo/wiki
 
 # Load variables for other script files to use (versions to download and such)

--- a/docs/docs/developerhelp/setup.md
+++ b/docs/docs/developerhelp/setup.md
@@ -94,7 +94,7 @@ Skip step 2 if you are not using Windows!
 
 5. Run the "post-start.sh" script from the `.devcontainer` folder:
     ```bash
-    ./.devcotainer/post-start.sh
+    ./.devcontainer/post-start.sh
     ```
 
 6. You should then have the Monorepo open inside of a dev container. 

--- a/docs/docs/developerhelp/setup.md
+++ b/docs/docs/developerhelp/setup.md
@@ -118,7 +118,7 @@ Now that you are inside of a dev container, we will go over how to get a running
     ```
 
 !!!note
-    Make sure that you have the secrets file and that minikube is running.
+    Make sure the secrets file is present and MiniKube is running.
 
 3. Now control + click on the URL that is shown: http://localhost:10350
 

--- a/docs/docs/developerhelp/setup.md
+++ b/docs/docs/developerhelp/setup.md
@@ -92,18 +92,20 @@ Skip step 2 if you are not using Windows!
 
 4. In the bottom right of the VS Code window you should be prompted to open as a dev container, if not press F1 and search for "Rebuild", click "Rebuild and Reopen in Container"
 
-5. Run the "post-start.sh" script from the root folder:
+5. Run the "post-start.sh" script from the `.devcontainer` folder:
     ```bash
-    ./post-start.sh
+    ./.devcotainer/post-start.sh
     ```
 
-5. Start MiniKube by typing the following:
+6. You should then have the Monorepo open inside of a dev container. 
+
+7. Start MiniKube by typing the following:
 
     ```bash
     minikube start
     ``` 
 
-6. You should then have the Monorepo open inside of a dev container. 
+    This is necessary for Tilt to work.
 
 ## Getting Started with the Monorepo
 
@@ -118,7 +120,7 @@ Now that you are inside of a dev container, we will go over how to get a running
     ```
 
 !!!note
-    Make sure the secrets file is present and MiniKube is running.
+    Make sure the secrets file is present and MiniKube is running (see "How to setup").
 
 3. Now control + click on the URL that is shown: http://localhost:10350
 

--- a/docs/docs/developerhelp/setup.md
+++ b/docs/docs/developerhelp/setup.md
@@ -92,7 +92,16 @@ Skip step 2 if you are not using Windows!
 
 4. In the bottom right of the VS Code window you should be prompted to open as a dev container, if not press F1 and search for "Rebuild", click "Rebuild and Reopen in Container"
 
-5. If you are using Mac OS, ensure that you have the VS Code extension "Dev Container" installed. If you are on Windows, it can be installed automatically.
+5. Run the "post-start.sh" script from the root folder:
+    ```bash
+    ./post-start.sh
+    ```
+
+5. Start MiniKube by typing the following:
+
+    ```bash
+    minikube start
+    ``` 
 
 6. You should then have the Monorepo open inside of a dev container. 
 
@@ -107,6 +116,9 @@ Now that you are inside of a dev container, we will go over how to get a running
     ```bash
     tilt up
     ```
+
+!!!note
+    Make sure that you have the secrets file and that minikube is running.
 
 3. Now control + click on the URL that is shown: http://localhost:10350
 

--- a/docs/docs/tutorial/best_practices.md
+++ b/docs/docs/tutorial/best_practices.md
@@ -4,6 +4,9 @@ This page will give a brief overview of the best practices for using GLADOS. For
 
 ## Repository Structure
 
+!!!note
+    The GLADOS CLI is contained within a separate repository. This section refers to the main repository, Monorepo.
+
 The GLADOS repository is structured to allow for easy navigation and understanding of the system. The main components of the repository are:
 
 ### Code Structure


### PR DESCRIPTION
- Deprecated the old (possibly broken) dev-install.sh and made it print a warning instead
- Updated documentation with new setup instructions